### PR TITLE
Make client's backing `LoopResources` configurable via `ConnectionFactoryOptions`

### DIFF
--- a/src/main/java/org/mariadb/r2dbc/MariadbConnectionFactoryProvider.java
+++ b/src/main/java/org/mariadb/r2dbc/MariadbConnectionFactoryProvider.java
@@ -10,6 +10,7 @@ import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
 import java.time.Duration;
 import org.mariadb.r2dbc.util.Assert;
+import reactor.netty.resources.LoopResources;
 
 public final class MariadbConnectionFactoryProvider implements ConnectionFactoryProvider {
   public static final String MARIADB_DRIVER = "mariadb";
@@ -33,6 +34,7 @@ public final class MariadbConnectionFactoryProvider implements ConnectionFactory
   public static final Option<Boolean> TCP_KEEP_ALIVE = Option.valueOf("tcpKeepAlive");
   public static final Option<Boolean> TCP_ABORTIVE_CLOSE = Option.valueOf("tcpAbortiveClose");
   public static final Option<String> SESSION_VARIABLES = Option.valueOf("sessionVariables");
+  public static final Option<LoopResources> LOOP_RESOURCES = Option.valueOf("loopResources");
 
   static MariadbConnectionConfiguration createConfiguration(
       ConnectionFactoryOptions connectionFactoryOptions) {

--- a/src/main/java/org/mariadb/r2dbc/client/ClientImpl.java
+++ b/src/main/java/org/mariadb/r2dbc/client/ClientImpl.java
@@ -39,7 +39,10 @@ public final class ClientImpl extends ClientBase {
       SocketAddress socketAddress,
       MariadbConnectionConfiguration configuration) {
 
-    TcpClient tcpClient = TcpClient.create(connectionProvider).remoteAddress(() -> socketAddress);
+    TcpClient tcpClient =
+        TcpClient.create(connectionProvider)
+            .remoteAddress(() -> socketAddress)
+            .runOn(configuration.loopResources());
     tcpClient = setSocketOption(configuration, tcpClient);
     return tcpClient.connect().flatMap(it -> Mono.just(new ClientImpl(it, configuration)));
   }

--- a/src/main/java/org/mariadb/r2dbc/client/ClientPipelineImpl.java
+++ b/src/main/java/org/mariadb/r2dbc/client/ClientPipelineImpl.java
@@ -35,7 +35,10 @@ public final class ClientPipelineImpl extends ClientBase {
       SocketAddress socketAddress,
       MariadbConnectionConfiguration configuration) {
 
-    TcpClient tcpClient = TcpClient.create(connectionProvider).remoteAddress(() -> socketAddress);
+    TcpClient tcpClient =
+        TcpClient.create(connectionProvider)
+            .remoteAddress(() -> socketAddress)
+            .runOn(configuration.loopResources());
     tcpClient = setSocketOption(configuration, tcpClient);
     return tcpClient.connect().flatMap(it -> Mono.just(new ClientPipelineImpl(it, configuration)));
   }


### PR DESCRIPTION
#### Motivation:
* #20

#### Modifications:
* Add `loopResources` property in `MariadbConnectionFactoryConfiguration` and run `TcpClient`on it.
* Provide `Option<LoopResources>` to be parsed from `ConnectionFactoryOptions` and used to build `MariadbConnectionFactoryConfiguration`.

Please, feel free to close the PR or provide feedback if it doesn't fit into what the library is aiming at.