### PR TITLE
metadata is null

### DIFF
--- a/src/main/java/org/mariadb/r2dbc/client/MariadbResult.java
+++ b/src/main/java/org/mariadb/r2dbc/client/MariadbResult.java
@@ -161,7 +161,7 @@ public class MariadbResult extends AbstractReferenceCounted
 
               ByteBuf buf = getLongTextEncoded(okPacket.getLastInsertId());
               org.mariadb.r2dbc.api.MariadbRow row = new MariadbRowText(buf, tmpMeta, factory);
-              sink.next(f.apply(row, meta.get()));
+              sink.next(f.apply(row, row.getMetadata()));
               ReferenceCountUtil.release(row);
             }
             return;


### PR DESCRIPTION

Error occurred while saving

```kotlin
@GetMapping("/error")
suspend fun save(): Account {
    return accountReposiotry.save(Account(null, "wonwoo")).awaitSingle() //error
}



@GetMapping("/")
fun find(): Flow<Account> {
    return accountReposiotry.findAll().asFlow() // not error
}
```
Error log 
```
Cannot invoke "Object.getClass()" because "obj" is null
```

spring boot 3.0.1
mariadb-connector-r2dbc 1.1.3
