### PR TITLE
[misc] use system trust store if serverSslCert is not set

### DIFF
--- a/src/main/java/org/mariadb/r2dbc/util/SslConfig.java
+++ b/src/main/java/org/mariadb/r2dbc/util/SslConfig.java
@@ -11,6 +11,8 @@ import java.io.*;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManagerFactory;
+
 import org.mariadb.r2dbc.SslMode;
 
 public class SslConfig {
@@ -89,8 +91,8 @@ public class SslConfig {
           }
         }
       } else {
-        throw new R2dbcTransientResourceException(
-            "Server certificate needed (option `serverSslCert`) for ssl mode " + sslMode, "08000");
+        // use the system default, i.e. verify against PKI
+        sslCtxBuilder.trustManager((TrustManagerFactory) null);
       }
     }
     if (clientSslCert != null && clientSslKey != null) {


### PR DESCRIPTION
Currently, the R2DBC connector seems to differ from the JDBC connector in that it can't enable TLS without explicitly specifying a `serverSslCert` or picking the non-production ready trust mode, by explicitly throwing an error in this code path.

The same way JDBC does it, I think it's reasonable to interpret this as "defer to PKI" or more specifically "defer to the system truststore" instead. The netty `SslContextBuilder` says to pass `null` for this (which is slightly more explicit than just not calling a `trustManager` function at all in that case).

See: https://netty.io/4.1/api/io/netty/handler/ssl/SslContextBuilder.html#trustManager-javax.net.ssl.TrustManagerFactory-